### PR TITLE
Added label and prompt option

### DIFF
--- a/src/Datagrid.php
+++ b/src/Datagrid.php
@@ -14,10 +14,9 @@ use Nette\Bridges\ApplicationLatte\Template;
 use Nette\Forms\Container;
 use Nette\Forms\Controls\Button;
 use Nette\Forms\Controls\Checkbox;
+use Nette\Localization\ITranslator;
 use Nette\Utils\Html;
 use Nette\Utils\Paginator;
-use Nette\Localization\ITranslator;
-
 
 class Datagrid extends UI\Control
 {
@@ -102,6 +101,11 @@ class Datagrid extends UI\Control
 	/** @var string */
 	protected $filterFormHttpMethod = 'post';
 
+	/** @var string */
+	protected $globalActionSelectPrompt = '- select action -';
+
+	/** @var string */
+	protected $globalActionProcessLabel = 'Do';
 
 	/**
 	 * Adds column
@@ -280,6 +284,22 @@ class Datagrid extends UI\Control
 		return $translator === null || $s == null || $s instanceof Html // intentionally ==
 			? $s
 			: $translator->translate((string) $s, $count);
+	}
+
+	/**
+	 * @param string $globalActionSelectPrompt
+	 */
+	public function setGlobalActionSelectPrompt($globalActionSelectPrompt)
+	{
+		$this->globalActionSelectPrompt = $globalActionSelectPrompt;
+	}
+
+	/**
+	 * @param string $globalActionProcessLabel
+	 */
+	public function setGlobalActionProcessLabel($globalActionProcessLabel)
+	{
+		$this->globalActionProcessLabel = $globalActionProcessLabel;
 	}
 
 
@@ -488,9 +508,9 @@ class Datagrid extends UI\Control
 			$actions = array_map(function($row) { return $row[0]; }, $this->globalActions);
 			$form['actions'] = new Container();
 			$form['actions']->addSelect('action', 'Action', $actions)
-				->setPrompt('- select action -');
+				->setPrompt($this->globalActionSelectPrompt);
 			$form['actions']->addCheckboxList('items', '', []);
-			$form['actions']->addSubmit('process', 'Do');
+			$form['actions']->addSubmit('process', $this->globalActionProcessLabel);
 		}
 
 		if ($this->translator) {


### PR DESCRIPTION
Simplifies:
```
$datagrid->onRender[] = function (Datagrid $datagrid): void {
	if (isset($datagrid['form']['actions']['action'])) {
		/** @var \Nette\Forms\Controls\SelectBox $selectBox */
		$selectBox = $datagrid['form']['actions']['action'];
		$selectBox->setPrompt('globalActions.action.prompt');
	}

	if (isset($datagrid['form']['actions']['process'])) {
		/** @var \Nette\Forms\Controls\SubmitButton $selectBox */
		$selectBox = $datagrid['form']['actions']['process'];
		$selectBox->caption = 'globalActions.process.label';
	}
}
```

To 
```
$datagrid->setGlobalActionSelectPrompt('globalActions.action.prompt');
$datagrid->setGlobalActionProcessLabel('globalActions.process.label');
```

Or some better solution ?